### PR TITLE
SOEN-131: Added Page titles for admin + tab titles

### DIFF
--- a/frontend/components/admin/approve-users/approve-users.tsx
+++ b/frontend/components/admin/approve-users/approve-users.tsx
@@ -20,7 +20,7 @@ export default function ApproveUsers (sessionId: Number)  {
         <Fragment>
             {isLoading && <Spinner />}
             {!!users && (
-                <Box>
+                <Box py={5}>
                     <Container>
                         <List spacing={10}>
                             <UserList
@@ -33,7 +33,7 @@ export default function ApproveUsers (sessionId: Number)  {
                                     alignItems: "left",
                                 }}
                                 key="1"
-                                title="pending"
+                                title="Pending Users"
                                 length={users["Users"].length}>
                                 {users["Users"].map((item: UserInfoSimple) => (
                                     <ApproveUsersRowCard

--- a/frontend/components/admin/patient/patient-lists.tsx
+++ b/frontend/components/admin/patient/patient-lists.tsx
@@ -44,7 +44,7 @@ const PatientLists = ({ sessionId }: AppProps) => {
             {isError && <p id="error-message"> There is an error </p>}
 
             {!isError && !isLoading && (
-                <Box px={{ base: 0, sm: 1, md: 4, lg: 1 }} py={20}>
+                <Box px={{ base: 0, sm: 1, md: 4, lg: 1 }} py={5}>
                     <Box
                         overflowY={{ base: "auto", md: "scroll" }}
                         overflowX={"hidden"}

--- a/frontend/components/admin/user-lists.tsx
+++ b/frontend/components/admin/user-lists.tsx
@@ -34,7 +34,7 @@ const UserLists = ({ sessionId }: appProps) => {
             {isError && <p id="error-message"> There is an error </p>}
 
             {!!userRoles && (
-                <Box px={{ base: 0, sm: 1, md: 4, lg: 1 }} py={20}>
+                <Box px={{ base: 0, sm: 1, md: 4, lg: 1 }} py={5}>
                     <SimpleGrid
                         columns={{ sm: 1, md: 2, lg: 2, xl: 2 }}
                         gap="8"

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -1,18 +1,26 @@
 import { SessionProvider } from "next-auth/react";
 import type { AppProps } from "next/app";
 import "@frontend/styles/globals.scss";
-import { ChakraProvider } from "@chakra-ui/react";
+import { ChakraProvider, Heading, Flex } from "@chakra-ui/react";
 import NavBar from "@frontend/components/navigation/navbar";
 import Footer from "@frontend/components/navigation/footer";
 
 export default function App({ Component, pageProps: { session, ...pageProps } }: AppProps) {
     // SessionProvider outside or ChakraProvider outside?
+    let pageTitle = pageProps.pageId; // To distinguish between tab name and page title. Only using pageId results in the homepage displaying the title above the welcome message.
+    if(!pageTitle)
+    {
+        pageTitle = "CoCo Tracker";
+    }
     return (
         <SessionProvider session={session}>
             <ChakraProvider>
                 <div id="App">
+                    <title>{pageTitle}</title>
                     <NavBar />
                     <div id="PageContents">
+                        {/* we do not use pageTitle here so that if not pageId is set, nothing is displayed. */}
+                        <Flex flexWrap={"wrap"} ml={"5vh"} mr={"5vh"}><Heading>{pageProps.pageId}</Heading></Flex>
                         <Component {...pageProps} />
                     </div>
                     <Footer />

--- a/frontend/pages/admin/approve-users.tsx
+++ b/frontend/pages/admin/approve-users.tsx
@@ -6,6 +6,7 @@ export async function getServerSideProps(context: any) {
     return {
         props: {
             session: await getSession(context),
+            pageId: "Manage Pending Users"
         },
     };
 }

--- a/frontend/pages/admin/patient-list.tsx
+++ b/frontend/pages/admin/patient-list.tsx
@@ -6,6 +6,7 @@ export async function getServerSideProps(context: GetSessionParams | undefined) 
     return {
         props: {
             session: await getSession(context),
+            pageId: "Manage Patients"
         },
     };
 }

--- a/frontend/pages/admin/user-list.tsx
+++ b/frontend/pages/admin/user-list.tsx
@@ -7,6 +7,7 @@ export async function getServerSideProps(context: NextPageContext) {
     return {
         props: {
             session: await getSession(context),
+            pageId: "Manage Active Users"
         },
     };
 }

--- a/frontend/styles/globals.scss
+++ b/frontend/styles/globals.scss
@@ -45,5 +45,3 @@ header {
   position: sticky;
   top: 0;
 }
-Footer {
-}


### PR DESCRIPTION
# Description

Implements/fixes [SOEN-131](https://soen390team8.atlassian.net/browse/SOEN-131?atlOrigin=eyJpIjoiNjAwMDM1MTgxZTgzNDlkZmE5MzNiMDFkZmNmMjdmYjgiLCJwIjoiaiJ9)

- Added centralized location for page titles
- Added tab title as complementary use of new prop
- Added page title to admin pages only for now (Add your own page titles at your leisure)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This feature has been tested manually by looking at the displayed text on the pages + the tab name. 
This specific improvement does not require any testing as it feels pointless to do so, it offers no real function addition to the code base.
It's a very minor change.

# Screenshots

|         Original          |         Updated          |
| :-----------------------: | :----------------------: |
|![image](https://user-images.githubusercontent.com/43119712/157126280-35c649ed-3ef8-423f-b14e-0689a6348473.png) | ![image](https://user-images.githubusercontent.com/43119712/157126335-872ae9a7-1569-4839-b25a-4772cd31b0a8.png)* |
|![image](https://user-images.githubusercontent.com/43119712/157126899-16f46ddf-ed9d-481d-926b-b6e135b22d3d.png) | !![image](https://user-images.githubusercontent.com/43119712/157126783-34375efa-6fd3-427d-ab12-1f8bbf5453df.png) |