### PR TITLE
Soen169 appointment overview bugs

### DIFF
--- a/frontend/components/doctor/patient-charts-overview.tsx
+++ b/frontend/components/doctor/patient-charts-overview.tsx
@@ -40,7 +40,7 @@ export default function PatientChartsOverview({ patientList }: { patientList: Pa
                         <TabPanel>
                             <PieChart
                                 statuses={extractStatuses(patientList)}
-                                title="All patients' symptoms"
+                                title="Patients' Symptoms"
                                 h={250}
                                 w={300}
                                 day={pieChartDate}
@@ -61,7 +61,7 @@ export default function PatientChartsOverview({ patientList }: { patientList: Pa
                         <TabPanel>
                             <PieChart
                                 statuses={extractStatuses(patientList)}
-                                title="All patients' symptoms"
+                                title="Patients' Symptoms of All Time"
                                 h={250}
                                 w={300}
                                 day={DAY.ALL}
@@ -84,7 +84,7 @@ export default function PatientChartsOverview({ patientList }: { patientList: Pa
                                 statuses={extractStatuses(patientList)}
                                 transformDataFn={transformWeightTempData}
                                 day={scatterChartDate}
-                                title={"Patients' Temperature and Weight Today"}
+                                title={"Patients' Temperature and Weight"}
                                 h={275}
                                 w={300}
                             />

--- a/frontend/components/forms/new-appointment-form.tsx
+++ b/frontend/components/forms/new-appointment-form.tsx
@@ -98,6 +98,7 @@ export default function NewAppointmentForm({
                             onChange={e => pickDate(e.target.value)}
                             style={datePickerStyle}
                             min={today}
+                            maxW={175}
                         />
                         <FormLabel mx={3} fontSize="lg" htmlFor="apt-time">
                             at
@@ -106,7 +107,7 @@ export default function NewAppointmentForm({
                             flex="3.65"
                             placeholder="Pick a time"
                             name="apt-time"
-                            maxWidth={[300, 300, 150, 150]}
+                            maxWidth={[300, 300, 175, 175]}
                             onChange={e => selectTime(e.target.value)}>
                             {APPOINTMENT_TIMESLOTS.map(timeslot => (
                                 <option key={timeslot} value={timeslot} disabled={disableOption(timeslot)}>

--- a/frontend/components/pie-chart.tsx
+++ b/frontend/components/pie-chart.tsx
@@ -30,13 +30,13 @@ export default function Chart({ statuses, title, h, w, day }: ChartProps) {
     const data = transformSymptomsData(statuses, day);
     return (
         <Box minW={350} minH={200}>
+            <Center>
+                <Text my={2} mb={4} fontSize="lg">
+                    {title}
+                </Text>
+            </Center>
             {data.length ? (
                 <Box>
-                    <Center>
-                        <Text my={2} mb={4} fontSize="lg">
-                            {title}
-                        </Text>
-                    </Center>
                     <Center>
                         <ResponsiveContainer minWidth={w} minHeight={h}>
                             <PieChart>

--- a/frontend/components/scatter-chart.tsx
+++ b/frontend/components/scatter-chart.tsx
@@ -19,11 +19,11 @@ export default function Chart({ statuses, transformDataFn, day, title, h, w }: C
     const data = transformDataFn(statuses, day);
     return (
         <Box>
+            <Center>
+                <Text fontSize="lg">{title}</Text>
+            </Center>
             {data.data.length ? (
                 <Box>
-                    <Center>
-                        <Text fontSize="lg">{title}</Text>
-                    </Center>
                     <Center>
                         <ScatterChart
                             width={w}

--- a/frontend/pages/doctor/appointments-overview.tsx
+++ b/frontend/pages/doctor/appointments-overview.tsx
@@ -62,7 +62,7 @@ export default function AppointmentsOverview({
                 `${appointment.date} ${appointment.time.substring(0, appointment.time.indexOf(" "))}`,
                 "YYYY-MM-DD HH:mm"
             );
-            if (appointmentDate.isBefore()) {
+            if (appointmentDate.isBefore() && appointmentDate.isSame(new Date(), "week")) {
                 pastAppointments.push(appointment);
             } else if (appointmentDate.isAfter()) {
                 upcomingAppointments.push(appointment);
@@ -90,7 +90,7 @@ export default function AppointmentsOverview({
                             <MinusIcon w={6} h={6} color="orange.200" mr={3} /> Pending
                         </Text>
                         <Text flex="1">
-                            <MinusIcon w={6} h={6} color="red.200" mr={3} /> Denied
+                            <MinusIcon w={6} h={6} color="red.200" mr={3} /> Declined
                         </Text>
                     </Box>
                     <Box h={{ sm: "800", lg: "600" }}>


### PR DESCRIPTION
# Description

Implements/fixes [SOEN-169](https://soen390team8.atlassian.net/jira/software/projects/SOEN/boards/1/backlog?selectedIssue=SOEN-169)

- Past appointments section only displays appointments up to 1 week
- Fixed new appointment modal content size
- Added title for empty charts in patients overview page

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

